### PR TITLE
Throw error if point cannot be converted

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StanLogDensityProblems"
 uuid = "a545de4d-8dba-46db-9d34-4e41d3f07807"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For easily benchmarking inference algorithms, StanLogDensityProblems also integr
 For example, here we sample a Stan model from PosteriorDB using [DynamicHMC](https://www.tamaspapp.eu/DynamicHMC.jl):
 
 ```julia
-julia> using BridgeStan, DynamicHMC, PosteriorDB, Random, StanLogDensityProblems
+julia> using DynamicHMC, PosteriorDB, Random, StanLogDensityProblems
 
 julia> pdb = PosteriorDB.database()
 PosteriorDatabase(...)
@@ -27,4 +27,10 @@ StanProblem: dogs_model
 julia> rng = Random.default_rng();
 
 julia> result = mcmc_with_warmup(rng, prob, 1_000; reporter=NoProgressReport());
+
+julia> result.posterior_matrix
+3×1000 Matrix{Float64}:
+  1.27568    1.29648    1.32405   …   1.65451    1.3875     1.76917
+ -0.327308  -0.305644  -0.303549     -0.273245  -0.387199  -0.333485
+ -0.128237  -0.166094  -0.15898      -0.223369  -0.15062   -0.236186
 ```

--- a/src/stanproblem.jl
+++ b/src/stanproblem.jl
@@ -1,7 +1,7 @@
 """
     StanProblem(model::BridgeStan.StanModel; nan_on_error::Bool=false)
 
-A wrapper for a Stan model with data, implementing the
+A wrapper for an unconstrained Stan model with data, implementing the
 [LogDensityProblems](https://www.tamaspapp.eu/LogDensityProblems.jl/) interface.
 
 If `nan_on_error=true`, then any errors from Stan will be suppressed, and `NaN`s will be

--- a/src/stanproblem.jl
+++ b/src/stanproblem.jl
@@ -50,8 +50,9 @@ function LogDensityProblems.logdensity(
     prob::StanProblem{M,nan_on_error}, x
 ) where {M,nan_on_error}
     m = prob.model
+    z = convert(Vector{Float64}, x)
     try
-        return BridgeStan.log_density(m, convert(Vector{Float64}, x))
+        return BridgeStan.log_density(m, z)
     catch
         nan_on_error || rethrow()
         return NaN
@@ -62,8 +63,9 @@ function LogDensityProblems.logdensity_and_gradient(
     prob::StanProblem{M,nan_on_error}, x
 ) where {M,nan_on_error}
     m = prob.model
+    z = convert(Vector{Float64}, x)
     try
-        return BridgeStan.log_density_gradient(m, convert(Vector{Float64}, x))
+        return BridgeStan.log_density_gradient(m, z)
     catch
         nan_on_error || rethrow()
         n = BridgeStan.param_unc_num(m)
@@ -75,8 +77,9 @@ function LogDensityProblems.logdensity_gradient_and_hessian(
     prob::StanProblem{M,nan_on_error}, x
 ) where {M,nan_on_error}
     m = prob.model
+    z = convert(Vector{Float64}, x)
     try
-        return BridgeStan.log_density_hessian(m, convert(Vector{Float64}, x))
+        return BridgeStan.log_density_hessian(m, z)
     catch
         nan_on_error || rethrow()
         n = BridgeStan.param_unc_num(m)


### PR DESCRIPTION
This PR primarily moves the line that converts the input point outside of the try catch block so that if it fails an error is thrown. It also makes a few documentation tweaks.