### PR TITLE
Bump Julia lower bound

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.8'
           - '1'
           - 'pre'
         os:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         version:
           - '1.8'
+          - 'lts'
           - '1'
           - 'pre'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StanLogDensityProblems"
 uuid = "a545de4d-8dba-46db-9d34-4e41d3f07807"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ BridgeStan = "1, 2"
 LogDensityProblems = "1, 2"
 PosteriorDB = "0.3.2, 0.4, 0.5"
 Requires = "0.5, 1"
-julia = "1.6"
+julia = "1.8"
 
 [extensions]
 StanLogDensityProblemsPosteriorDBExt = "PosteriorDB"


### PR DESCRIPTION
Currently the CI fails for Julia v1.6. I'm not entirely certain why, but since v1.10 is now the LTS, it's fine to drop support for older versions. This PR sets the new lower bound to v1.8.