### PR TITLE
Stop using deprecated StanModel constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StanLogDensityProblems"
 uuid = "a545de4d-8dba-46db-9d34-4e41d3f07807"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-BridgeStan = "2"
+BridgeStan = "2.3.0"
 LogDensityProblems = "2.1.0"
 PosteriorDB = "0.3.2, 0.4, 0.5"
 Requires = "0.5, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 [compat]
 BridgeStan = "2.3.0"
 LogDensityProblems = "2.1.0"
-PosteriorDB = "0.3.2, 0.4, 0.5"
+PosteriorDB = "0.5"
 Requires = "0.5, 1"
 julia = "1.8"
 

--- a/ext/StanLogDensityProblemsPosteriorDBExt.jl
+++ b/ext/StanLogDensityProblemsPosteriorDBExt.jl
@@ -11,7 +11,8 @@ end
 """
     StanProblem(
         posterior::PosteriorDB.Posterior,
-        path::AbstractString;
+        path::AbstractString,
+        args...;
         nan_on_error::Bool=false,
         force::Bool=false,
         kwargs...,
@@ -23,16 +24,18 @@ Construct a `StanProblem` from the Stan model implementation and dataset corresp
 The model file will be copied to `path` before compilation. `force=true` will first remove
 an existing file. However, if the original file has already been compiled in this directory,
 the new model will not be compiled.
+
+Remaining `args` and `kwargs` are forwarded to the main constructor.
 """
 function StanLogDensityProblems.StanProblem(
-    post::PosteriorDB.Posterior, path::AbstractString; force::Bool=false, kwargs...
+    post::PosteriorDB.Posterior, path::AbstractString, args...; force::Bool=false, kwargs...
 )
     model = PosteriorDB.model(post)
     stan_file = PosteriorDB.path(PosteriorDB.implementation(model, "stan"))
     stan_file_new = joinpath(path, basename(stan_file))
     cp(stan_file, stan_file_new; force=force)
     data = PosteriorDB.load(PosteriorDB.dataset(post), String)
-    return StanLogDensityProblems.StanProblem(stan_file_new, data; kwargs...)
+    return StanLogDensityProblems.StanProblem(stan_file_new, data, args...; kwargs...)
 end
 
 end  # module

--- a/src/stanproblem.jl
+++ b/src/stanproblem.jl
@@ -15,14 +15,12 @@ struct StanProblem{M<:BridgeStan.StanModel,nan_on_error}
 end
 
 """
-    StanProblem(stan_file::String, data::String; nan_on_error::Bool=false, kwargs...)
+    StanProblem(lib::String[, data::String[ seed::Int]]; nan_on_error::Bool=false, kwargs...)
 
-Construct a `BridgeStan.StanModel` from a `.stan` file and wrap it as a `StanProblem`.
+Construct a `BridgeStan.StanModel` and wrap it as a `StanProblem`.
 
-`data` should either be a string containing a JSON string literal or a path to a data file
-ending in `.json`. If necessary, the model is compiled.
-
-Remaining `kwargs` are forwarded to
+`lib` is a path either to a compiled Stan model or to a `.stan` file. For details on the
+arguments, see the docstring for
 [`BridgeStan.StanModel`](https://roualdes.github.io/bridgestan/languages/julia.html#BridgeStan.StanModel).
 
 !!! note

--- a/src/stanproblem.jl
+++ b/src/stanproblem.jl
@@ -29,8 +29,8 @@ Remaining `kwargs` are forwarded to
     By default, Stan does not compile the model with multithreading support. If this is
     needed, pass `make_args=["STAN_THREADS=true"]` to `kwargs`.
 """
-function StanProblem(stan_file::String, data::String; nan_on_error::Bool=false, kwargs...)
-    model = BridgeStan.StanModel(; stan_file, data, kwargs...)
+function StanProblem(args...; nan_on_error::Bool=false, kwargs...)
+    model = BridgeStan.StanModel(args...; kwargs...)
     return StanProblem(model; nan_on_error=nan_on_error)
 end
 

--- a/test/stanproblem.jl
+++ b/test/stanproblem.jl
@@ -14,7 +14,7 @@ end
 
 function get_test_model(name; kwargs...)
     stan_file, data = get_test_files(name)
-    return BridgeStan.StanModel(; stan_file, data, kwargs...)
+    return BridgeStan.StanModel(stan_file, data; kwargs...)
 end
 
 struct NonNumeric{T}


### PR DESCRIPTION
Fixes #17 . Because the new constructor only accepts `.stan` files for BridgeStan >= v2.3.0, we drop support for old versions. Because older versions of PosteriorDB use `.stan` files with discontinued syntax, we also drop support for PosteriorDB < v0.5