### PR TITLE
Use DocumenterInterLinks to link to BridgeStan

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 PosteriorDB = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
 StanLogDensityProblems = "a545de4d-8dba-46db-9d34-4e41d3f07807"

--- a/docs/inventories/BridgeStan.toml
+++ b/docs/inventories/BridgeStan.toml
@@ -1,0 +1,8 @@
+# DocInventory version 1
+project = "BridgeStan.jl"
+version = "2.6.1"
+
+# NOTE: trimmed to just the API functions we link to
+[[jl.type]]
+name = "BridgeStan.StanModel"
+uri = "/languages/julia.html#$"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,17 @@
 using StanLogDensityProblems
 using Documenter
+using DocumenterInterLinks
 using PosteriorDB  # load extension
 
 DocMeta.setdocmeta!(
     StanLogDensityProblems, :DocTestSetup, :(using StanLogDensityProblems); recursive=true
+)
+
+links = InterLinks(
+    "BridgeStan" => (
+        "https://roualdes.github.io/bridgestan/latest/",
+        joinpath(@__DIR__, "inventories", "BridgeStan.toml"),
+    ),
 )
 
 makedocs(;
@@ -17,6 +25,7 @@ makedocs(;
         edit_link="main",
         assets=String[],
     ),
+    plugins=[links],
     pages=["Home" => "index.md"],
 )
 

--- a/src/stanproblem.jl
+++ b/src/stanproblem.jl
@@ -17,11 +17,10 @@ end
 """
     StanProblem(lib::String[, data::String[ seed::Int]]; nan_on_error::Bool=false, kwargs...)
 
-Construct a `BridgeStan.StanModel` and wrap it as a `StanProblem`.
+Construct a [`BridgeStan.StanModel`](@extref) and wrap it as a `StanProblem`.
 
 `lib` is a path either to a compiled Stan model or to a `.stan` file. For details on the
-arguments, see the docstring for
-[`BridgeStan.StanModel`](https://roualdes.github.io/bridgestan/languages/julia.html#BridgeStan.StanModel).
+arguments, see the docstring for [`BridgeStan.StanModel`](@extref).
 
 !!! note
     By default, Stan does not compile the model with multithreading support. If this is


### PR DESCRIPTION
This is a minor change. While BridgeStan docs a re built with sphinx so include an inventory that Documenter can use to link to their docs via DocumenterInterLinks (DIL), only references to their Python classes (not Julia types) are included in the inventory. This PR adds a custom inventory with the missing URI so we can remove the explicit URL from the docstring and rely on DIL.