### PR TITLE
Don't copy Stan file if it already exists

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,12 +7,14 @@ version = "0.1.7"
 BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
 LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
 BridgeStan = "2"
 LogDensityProblems = "2.1.0"
 PosteriorDB = "0.3.2, 0.4, 0.5"
 Requires = "0.5, 1"
+SHA = "0.7, 1"
 julia = "1.8"
 
 [extensions]

--- a/Project.toml
+++ b/Project.toml
@@ -12,9 +12,10 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 [weakdeps]
 PosteriorDB = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [extensions]
-StanLogDensityProblemsPosteriorDBExt = "PosteriorDB"
+StanLogDensityProblemsPosteriorDBExt = ["PosteriorDB", "SHA"]
 
 [compat]
 BridgeStan = "2.3.0"

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [weakdeps]
 PosteriorDB = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [extensions]
 StanLogDensityProblemsPosteriorDBExt = "PosteriorDB"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StanLogDensityProblems"
 uuid = "a545de4d-8dba-46db-9d34-4e41d3f07807"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,12 @@ LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
+[weakdeps]
+PosteriorDB = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
+
+[extensions]
+StanLogDensityProblemsPosteriorDBExt = "PosteriorDB"
+
 [compat]
 BridgeStan = "2"
 LogDensityProblems = "2.1.0"
@@ -17,15 +23,9 @@ Requires = "0.5, 1"
 SHA = "0.7, 1"
 julia = "1.8"
 
-[extensions]
-StanLogDensityProblemsPosteriorDBExt = "PosteriorDB"
-
 [extras]
 PosteriorDB = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["PosteriorDB", "Test"]
-
-[weakdeps]
-PosteriorDB = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"

--- a/ext/StanLogDensityProblemsPosteriorDBExt.jl
+++ b/ext/StanLogDensityProblemsPosteriorDBExt.jl
@@ -4,11 +4,10 @@ using StanLogDensityProblems: StanLogDensityProblems, EXTENSIONS_SUPPORTED
 
 if EXTENSIONS_SUPPORTED
     using PosteriorDB: PosteriorDB
-    using SHA: SHA
 else  # using Requires
     using ..PosteriorDB: PosteriorDB
-    using ..SHA: SHA
 end
+using SHA: SHA
 
 """
     StanProblem(

--- a/ext/StanLogDensityProblemsPosteriorDBExt.jl
+++ b/ext/StanLogDensityProblemsPosteriorDBExt.jl
@@ -35,12 +35,14 @@ function StanLogDensityProblems.StanProblem(
     model = PosteriorDB.model(post)
     stan_file = PosteriorDB.path(PosteriorDB.implementation(model, "stan"))
     stan_file_new = joinpath(path, basename(stan_file))
-    if !isfile(stan_file_new) || _hash(stan_file_new) != _hash(stan_file)
+    if !isfile(stan_file_new) || !_is_file_identical(stan_file_new, stan_file)
         cp(stan_file, stan_file_new; force=force)
     end
     data = PosteriorDB.load(PosteriorDB.dataset(post), String)
     return StanLogDensityProblems.StanProblem(stan_file_new, data, args...; kwargs...)
 end
+
+_is_file_identical(f1::AbstractString, f2::AbstractString) = _hash(f1) == _hash(f2)
 
 _hash(file::AbstractString) = open(SHA.sha256, file; read=true)
 

--- a/ext/StanLogDensityProblemsPosteriorDBExt.jl
+++ b/ext/StanLogDensityProblemsPosteriorDBExt.jl
@@ -23,11 +23,11 @@ end
 Construct a `StanProblem` from the Stan model implementation and dataset corresponding to
 `posterior`.
 
-The model file will be copied to `path` before compilation. `force=true` will first remove
-an existing file. However, if the original file has already been compiled in this directory,
-the new model will not be compiled.
+The model file will be copied to `path` before compilation. If the file already exists in
+`path` and is not identical to the original file, it will be overwritten if `force=true`;
+otherwise, an error will be thrown.
 
-Remaining `args` and `kwargs` are forwarded to the main constructor.
+Remaining `args` and `kwargs` are forwarded to the main `StanProblem` constructor.
 """
 function StanLogDensityProblems.StanProblem(
     post::PosteriorDB.Posterior, path::AbstractString, args...; force::Bool=false, kwargs...

--- a/test/posteriordb.jl
+++ b/test/posteriordb.jl
@@ -1,3 +1,4 @@
+using BridgeStan
 using LogDensityProblems
 using PosteriorDB
 using StanLogDensityProblems
@@ -8,14 +9,27 @@ using Test
     post = PosteriorDB.posterior(pdb, "dogs-dogs")
     @testset for nan_on_error in (false, true)
         path = mktempdir(; cleanup=false)
+        stan_file = joinpath(path, "dogs.stan")
         prob = StanProblem(post, path; nan_on_error=nan_on_error)
         @test prob isa StanProblem{<:BridgeStan.StanModel,nan_on_error}
-        @test isfile(joinpath(path, "dogs.stan"))
+        @test isfile(stan_file)
         dim = LogDensityProblems.dimension(prob)
         x = randn(dim)
         LogDensityProblems.logdensity(prob, x)
-        @test_throws ArgumentError StanProblem(post, path; nan_on_error=nan_on_error)
-        prob2 = StanProblem(post, path; force=true, nan_on_error=nan_on_error)
+
+        # Because Stan file has not changed, no error raised.
+        prob2 = StanProblem(post, path; nan_on_error=nan_on_error)
         LogDensityProblems.logdensity(prob2, x)
+
+        # Because file exists but is nonidentical, error raised.
+        # `cp` copies with the original permissions, so we can't modify the copy unless we
+        # change the permissions
+        chmod(stan_file, 0o644)
+        open(println, stan_file; append=true)
+        @test_throws ArgumentError StanProblem(post, path; nan_on_error=nan_on_error)
+
+        # Force re-copying Stan file.
+        prob3 = StanProblem(post, path; force=true, nan_on_error=nan_on_error)
+        LogDensityProblems.logdensity(prob3, x)
     end
 end


### PR DESCRIPTION
Before copying a Stan file from posteriordb, it now checks whether an existing file and the new file have identical hashes and only copies if they don't. Thus, if the model has not changed and has already been compiled, this avoids recompilation.

Fixes #18