### PR TITLE
ci: use PAT for TagBot releases

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TAGBOT_PAT }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
           changelog_format: conventional


### PR DESCRIPTION
Use the repository secret `TAGBOT_PAT` instead of `GITHUB_TOKEN` so TagBot can create releases whose targets add or modify workflow files relative to `main`.

Before merging, configure `TAGBOT_PAT` with `Contents: read and write` and `Workflows: read and write`.

Observed in #40.