### PR TITLE
chore: Drop support for Julia 1.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directories: # Location of Julia projects
       - "/"
       - "/docs"
+      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8'
+          - 'min'
           - 'lts'
           - '1'
           - 'pre'

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['lts']
+        version: ['1']
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v7
@@ -28,7 +28,10 @@ jobs:
       - uses: julia-actions/julia-downgrade-compat@v2
         with:
           mode: deps
+          projects: ".,test"
       - uses: julia-actions/julia-buildpkg@v1
+        with:
+          project: "test"
       - uses: julia-actions/julia-runtest@v1
         with:
           allow_reresolve: false

--- a/Project.toml
+++ b/Project.toml
@@ -9,17 +9,17 @@ projects = ["docs", "test"]
 [deps]
 BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
 LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
-SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [weakdeps]
 PosteriorDB = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [extensions]
-StanLogDensityProblemsPosteriorDBExt = "PosteriorDB"
+StanLogDensityProblemsPosteriorDBExt = ["PosteriorDB", "SHA"]
 
 [compat]
 BridgeStan = "2.3.0"
 LogDensityProblems = "2.1.0"
 PosteriorDB = "0.5, 0.6"
-SHA = "0.7, 1"
+SHA = "0.7"
 julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,33 +1,25 @@
 name = "StanLogDensityProblems"
 uuid = "a545de4d-8dba-46db-9d34-4e41d3f07807"
 authors = ["Seth Axen <seth@sethaxen.com> and contributors"]
-version = "0.1.11"
+version = "0.1.12"
+
+[workspace]
+projects = ["docs", "test"]
 
 [deps]
 BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
 LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [weakdeps]
 PosteriorDB = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [extensions]
-StanLogDensityProblemsPosteriorDBExt = ["PosteriorDB", "SHA"]
+StanLogDensityProblemsPosteriorDBExt = "PosteriorDB"
 
 [compat]
 BridgeStan = "2.3.0"
 LogDensityProblems = "2.1.0"
 PosteriorDB = "0.5, 0.6"
-Requires = "0.5, 1"
 SHA = "0.7, 1"
-julia = "1.8"
-
-[extras]
-PosteriorDB = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["PosteriorDB", "Test"]
+julia = "1.9"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,6 +4,9 @@ DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 PosteriorDB = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
 StanLogDensityProblems = "a545de4d-8dba-46db-9d34-4e41d3f07807"
 
+[sources]
+StanLogDensityProblems = {path = ".."}
+
 [compat]
 Documenter = "1.17.0"
 DocumenterInterLinks = "1.1.0"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,8 +10,6 @@ For easily benchmarking inference algorithms, StanLogDensityProblems also integr
 ```@autodocs
 Modules = [
     StanLogDensityProblems,
-    isdefined(Base, :get_extension) ?
-        Base.get_extension(StanLogDensityProblems, :StanLogDensityProblemsPosteriorDBExt) :
-        StanLogDensityProblems.StanLogDensityProblemsPosteriorDBExt
+    Base.get_extension(StanLogDensityProblems, :StanLogDensityProblemsPosteriorDBExt),
 ]
 ```

--- a/ext/StanLogDensityProblemsPosteriorDBExt.jl
+++ b/ext/StanLogDensityProblemsPosteriorDBExt.jl
@@ -1,12 +1,7 @@
 module StanLogDensityProblemsPosteriorDBExt
 
-using StanLogDensityProblems: StanLogDensityProblems, EXTENSIONS_SUPPORTED
-
-if EXTENSIONS_SUPPORTED
-    using PosteriorDB: PosteriorDB
-else  # using Requires
-    using ..PosteriorDB: PosteriorDB
-end
+using StanLogDensityProblems: StanLogDensityProblems
+using PosteriorDB: PosteriorDB
 using SHA: SHA
 
 """

--- a/src/StanLogDensityProblems.jl
+++ b/src/StanLogDensityProblems.jl
@@ -7,15 +7,4 @@ export StanProblem
 
 include("stanproblem.jl")
 
-const EXTENSIONS_SUPPORTED = isdefined(Base, :get_extension)
-EXTENSIONS_SUPPORTED || using Requires: @require
-
-function __init__()
-    @static if !EXTENSIONS_SUPPORTED
-        @require PosteriorDB = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4" begin
-            include("../ext/StanLogDensityProblemsPosteriorDBExt.jl")
-        end
-    end
-end
-
 end  # module

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,16 @@
+[deps]
+BridgeStan = "c88b6f0a-829e-4b0b-94b7-f06ab5908f5a"
+LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
+PosteriorDB = "1c4bc282-d2f5-44f9-b6d1-8c4424a23ad4"
+StanLogDensityProblems = "a545de4d-8dba-46db-9d34-4e41d3f07807"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+StanLogDensityProblems = {path = ".."}
+
+[compat]
+BridgeStan = "2.3.0"
+LogDensityProblems = "2.1.0"
+PosteriorDB = "0.5, 0.6"
+StanLogDensityProblems = "0.1.11"
+Test = "1"


### PR DESCRIPTION
Raise the minimum Julia version to 1.9 and rely exclusively on package extensions.

Also modernize the package layout by moving test dependencies into `test/Project.toml`, adding workspace and local source declarations, and updating CI accordingly.

Bumps the package version to 0.1.12.